### PR TITLE
NowJS and express compatibility. Fixed serving of nowjs files.

### DIFF
--- a/app.js
+++ b/app.js
@@ -56,7 +56,7 @@ app.get('/',function(req,res,next){
   staticProvider(req, res, next);
 });
 var port = process.env.PORT || 3149;
-app.listen(port); 
+var server = app.listen(port); 
  
 var EDITABLE_APPS_DIR = "/APPS/"; 
 var ENABLE_LAUNCH     = false;
@@ -418,7 +418,7 @@ app.get("/allUsersEditingProjects", function(req, res){
 // ------------------------------------------------------------
 var localFileIsMostRecent = []; // an array of flags indicating if the file has been modified since last save.
 var nowjs     = require("now");
-var everyone  = nowjs.initialize(app);
+var everyone  = nowjs.initialize(server);
 // ------ REALTIME NOWJS COLLABORATION ------
 //var nowcollab = require("../CHAOS/nowcollab");
 //nowcollab.initialize(nowjs, everyone, true);


### PR DESCRIPTION
I tried out Space_Editor locally on my Node (v0.8.8) setup, and found my browser couldn't load now.js files. Using an explicit http server on another port, and suitable modifying editFile.html to load from that port worked, as explained on NowJS Readme.

Their FAQ mentions a way to make NowJS serving work with express, this pull request incorporates that.
